### PR TITLE
📘 Fix broken README browser install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## The Problem
 
-![The problem](http://i.imgur.com/H1Ck3bF.png)
+![The problem](https://i.imgur.com/H1Ck3bF.png)
 
 <br>
 
@@ -50,7 +50,7 @@ sb.toBitcoin(100000000);
 
 ```html
 <!-- package injected as "sb" -->
-<script src="https://rawgit.com/dawsonbotsford/satoshi-bitcoin/master/index.bundle.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/satoshi-bitcoin/index.bundle.js"></script>
 <script>
   console.log("One Satoshi equals " + sb.toBitcoin(1) + " Bitcoin");
 </script>
@@ -94,7 +94,7 @@ TypeScript definitions are included — both functions accept a `number` or `str
   - Satoshi is to Bitcoin as pennies are to the dollar. Except that there are 100,000,000 Satoshi in one Bitcoin.
 
 - Why do I need a module when I can just divide or multiply by 100,000,000?
-  - [See here](http://repl.it/zlF/4) - Floating point errors are a problem. So `satoshi-bitcoin` uses a tiny bignum library (big.js) to ensure accurate conversions!
+  - [See here](https://repl.it/zlF/4) - Floating point errors are a problem. So `satoshi-bitcoin` uses a tiny bignum library (big.js) to ensure accurate conversions!
 
 <br>
 


### PR DESCRIPTION
## Problem

The **Web usage** section of the README was broken. The `<script>` tag pointed at `rawgit.com` (a CDN that [shut down in 2019](https://rawgit.com/)) under the old `dawsonbotsford` username, so anyone following the browser install instructions got a 404. A couple of other links also loaded over insecure `http://`.

## Fix

- Repoint the browser `<script>` example to jsDelivr: `https://cdn.jsdelivr.net/npm/satoshi-bitcoin/index.bundle.js` (verified returns **HTTP 200** and serves the published `index.bundle.js`).
- https-ify the imgur "problem" image and the repl.it link.

The stale `dawsonbotsford` username only appeared inside that dead rawgit URL, which is now gone entirely.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)